### PR TITLE
Add build action on push to main

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,8 @@
 name: Build Node
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
This resolves part A of our subtask from [here](https://github.com/ChicoState/PantryNode/issues/19#issuecomment-1453015431l). 

- [x] A. Enable the Build job to run on push to main.
- [ ] B. Get the linter in for all PRs (in progress)
- [ ] C. Clean up all linter issues
- [ ] D. Add a GitHub Action status badge to the README (and remove final bit of Travis CI in Readme)

Which then resolves one part of the task required for Issue [19](https://github.com/ChicoState/PantryNode/issues/19#issue-1591125555) .

- [ ] Remove all dependencies on Travis CI
- [x] Add a GitHub Action workflow to verify a successful build of the project. Should be triggered by all pull requests.
- [x] Add a GitHub Action workflow to perform static analysis of all pull requests.
- [ ] Add a GitHub Action status badge to README.md with the current build status of the main branch using the new CI workflow