### PR TITLE
Pushing straight to main: removed mongoose: 5.9.11 as we are migrating to Postgre SQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "jade": "~1.11.0",
     "jshint-reporter-badge": "^0.1.0",
     "jslint": "^0.12.1",
-    "mongoose": "^5.9.11",
     "morgan": "~1.9.1",
     "nodemon": "^2.0.3",
     "passport": "^0.4.1",


### PR DESCRIPTION
Removed mongoose: 5.9.11 from package.json as we are migrating to Postgre SQL