### PR TITLE
Add README instructions to run ESLint locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,19 @@ $ nodemon bin/www
 
 ## Static Code Analysis Tool 
 
-- JSLint
+- ESLint
+> Install ESLint dependencies
+
+```shell
+$ npm init @eslint/config
+$ npm install --save-dev @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-config-react-app eslint@^8.0.0 typescript
+```
+
+> Run ESLint Locally
+
+```shell
+$ npx eslint .
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -101,15 +101,14 @@ $ nodemon bin/www
 
 ## Static Code Analysis Tool 
 
-- ESLint
-> Install ESLint dependencies
+### ESLint
+#### Install ESLint dependencies
 
 ```shell
-$ npm init @eslint/config
 $ npm install --save-dev @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-config-react-app eslint@^8.0.0 typescript
 ```
 
-> Run ESLint Locally
+#### Run ESLint Locally
 
 ```shell
 $ npx eslint .

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ $ nodemon bin/www
 #### Install ESLint dependencies
 
 ```shell
-$ npm install --save-dev @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-config-react-app eslint@^8.0.0 typescript
+npm install --save-dev @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-config-react-app eslint@^8.0.0 typescript
 ```
 
 #### Run ESLint Locally
 
 ```shell
-$ npx eslint .
+npx eslint .
 ```
 
 ## Contributing


### PR DESCRIPTION
If reviewing my pull request, please follow instructions shown in changed files or in the 'run_lint_local' branch in the README.md under "Static Build Analysis Tools" for "ESLint" to confirm that it works on your local system.

Should 'running ESLint locally' have it's own section entirely? Currently, I took the liberty to just place it in the "Static Build Analysis Tools" section of the README.md

Completes the 4th task necessary for Issue #47. 

- [ ] Clean up **@typescript-eslint/no-var-requires**
- [ ] #48
- [ ] Clean up **no-undef**
- [x] Add "how to run the linter locally" to the README.md