### PR TITLE
Update package.json

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,6 @@
     "jade": "~1.11.0",
     "jshint-reporter-badge": "^0.1.0",
     "jslint": "^0.12.1",
-    "mongoose": "^5.9.11",
     "morgan": "~1.9.1",
     "nodemon": "^2.0.22",
     "passport": "^0.6.0",


### PR DESCRIPTION
removing the "mongoose": "^5.9.11" dependency from the project as we no longer require it due to our migration to Postgres SQL