### PR TITLE
Remove old models folder from Docker image

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,22 @@
+# Git files
+.git/
+.gitignore
+
+# IDE files
+.idea/
+
+# CI configuration files
+.travis.yml
+
+# Repo-Only Files
+docs/
+README.md
+
+# Build files
+node_modules/
+
+# postgres data folder
+postgres-data/
+
+# old files
+models-old/


### PR DESCRIPTION
When clearing everything and running `docker-compose up`, I noticed that my node (backend) container was crashing repeatedly because it was trying to connect to MongoDB. By ignoring the old models folder I ensure that my node container doesn't include them and doesn't have that issue.

To make this file I:
* Copied from root
* Added `models-old` folder

I believe this is the last thing for #46 