### PR TITLE
Sorting the data by expiry date by default

### DIFF
--- a/frontend/src/pages/expiry.tsx
+++ b/frontend/src/pages/expiry.tsx
@@ -173,6 +173,7 @@ const ExpiryIndex = () => {
       quantity: 1,
     } as expiryFeed,
   ]);
+
   const [selectedCategory, setSelectedCategory] = useState<string>("All");
   const [selectedSortBy, setSelectedSortBy] = useState<string>("Item");
   const [selectedSortBy2, setSelectedSortBy2] = useState<string>("Item");
@@ -192,7 +193,14 @@ const ExpiryIndex = () => {
       // setFeedList(JSON.parse(res) as expiryFeed[]);
 
       // Comment or Remove the below line for production use
-      setFeedList(JSON.parse(expiryDummyDataString) as expiryFeed[]);
+      const data = JSON.parse(expiryDummyDataString) as expiryFeed[];
+
+        const sortedData = data.sort((a, b) => {
+          const aExpiry = new Date(a.expiration).getTime();
+          const bExpiry = new Date(b.expiration).getTime();
+          return aExpiry - bExpiry;
+        });
+        setFeedList(sortedData);
     });
     axiosInstance
       .get<expiryFeed[]>("/items/nearly_expired")
@@ -201,7 +209,16 @@ const ExpiryIndex = () => {
         // setNearlyExpiredFeedList(JSON.parse(res) as expiryFeed[]);
 
         // Comment or Remove the below line for production use
-        setNearlyExpiredFeedList(JSON.parse(aboutToExpiryDummyDataString) as expiryFeed[]);
+        const data = JSON.parse(aboutToExpiryDummyDataString) as expiryFeed[];
+
+        const sortedData = data.sort((a, b) => {
+          const aExpiry = new Date(a.expiration).getTime();
+          const bExpiry = new Date(b.expiration).getTime();
+          return aExpiry - bExpiry;
+        });
+
+        setNearlyExpiredFeedList(sortedData);
+
       });
   }, []);
 


### PR DESCRIPTION
Previously, the data was being displayed in the order that was given. I have made a change to sort the data by expiry date as it makes more sense for the person who is taking a look at the page to see the item that is going to expire first to last. 