### PR TITLE
Set eslint no-var rule to error, resolves #181

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -20,6 +20,7 @@
     "linebreak-style": ["warn", "unix"],
     "quotes": ["warn", "double"],
     "semi": ["warn", "always"],
+    "no-var": "error",
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-unused-vars": "warn"
   },


### PR DESCRIPTION
This change set the 'no-var' rule to an error to prevent the project from building with the [current action workflows](https://github.com/ChicoState/PantryNode/actions/runs/4760422001/jobs/8460728583). See #181 for further discussion and reasoning.